### PR TITLE
fix: Add `src` attribtue to `<video />` for Chrome (#18)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,8 @@
     </a-scene>
     <a-scene id="ascn">
       <a-assets>
-        <video id="video" loop>
+        <!-- 空ではあるが, `src` 属性は必要 (https://github.com/sdm-wg/web360square/issues/18) -->
+        <video id="video" src="" loop muted />
       </a-assets>
       <a-entity id="camera" camera rotation-reader look-controls wasd-controls="acceleration: 200;"
         position="0 1.6 0">


### PR DESCRIPTION
### This PR will...

`video` タグに空の `src` 属性を追加しました.

### Why is this Pull Request needed?

aframe の実装上, `src` 属性がないと HLS 再生と判定されず, Chrome で映像が表示されない

### Resolves issues:

https://github.com/sdm-wg/web360square/issues/18